### PR TITLE
New certificate import

### DIFF
--- a/vh-core-infra/azuredeploy.json
+++ b/vh-core-infra/azuredeploy.json
@@ -106,6 +106,9 @@
     "RedisCacheName": {
       "type": "string"
     },
+    "KeyVaultCertificateSecretName": {
+      "type": "string"
+    },
     "_artifactsLocation": {
       "type": "string",
       "defaultValue": "https://raw.githubusercontent.com/hmcts/vh-arm-templates/master/vh-arm-templates"
@@ -147,7 +150,9 @@
         "parameters": {
           "appServicePlanName": { "value": "[parameters('appServicePlanName')]" },
           "sku": { "value": "[parameters('sku')]" },
-          "tier": { "value": "[parameters('tier')]" }
+          "tier": { "value": "[parameters('tier')]" },
+          "KeyVaultCertificateSecretName": { "value": "[parameters('KeyVaultCertificateSecretName')]" }
+
         }
       }
     },

--- a/vh-core-infra/azuredeploy.json
+++ b/vh-core-infra/azuredeploy.json
@@ -140,7 +140,10 @@
       "name": "AzureAppServicePlan",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2016-09-01",
-      "dependsOn": [ "KeyVault" ],
+      "dependsOn": [
+        "KeyVault",
+        "AzureKeyVaultAccessPolicy"
+      ],
       "properties": {
         "mode": "Incremental",
         "templateLink": {

--- a/vh-core-infra/azuredeploy.json
+++ b/vh-core-infra/azuredeploy.json
@@ -155,7 +155,7 @@
           "sku": { "value": "[parameters('sku')]" },
           "tier": { "value": "[parameters('tier')]" },
           "KeyVaultSecretName": { "value": "[parameters('KeyVaultCertificateSecretName')]" },
-          "KeyVaultId": { "value": "reference('KeyVault').outputs.resourceID.value" }
+          "KeyVaultId": { "value": "reference('KeyVault').outputs.AzureKeyVaultResourceId.value" }
 
         }
       }

--- a/vh-core-infra/azuredeploy.json
+++ b/vh-core-infra/azuredeploy.json
@@ -154,7 +154,7 @@
           "appServicePlanName": { "value": "[parameters('appServicePlanName')]" },
           "sku": { "value": "[parameters('sku')]" },
           "tier": { "value": "[parameters('tier')]" },
-          "KeyVaultSecretName": { "value": "[parameters('KeyVaultSecretName')]" },
+          "KeyVaultSecretName": { "value": "[parameters('KeyVaultCertificateSecretName')]" },
           "KeyVaultId": { "value": "reference('KeyVault').outputs.resourceID.value" }
 
         }

--- a/vh-core-infra/azuredeploy.json
+++ b/vh-core-infra/azuredeploy.json
@@ -154,7 +154,8 @@
           "appServicePlanName": { "value": "[parameters('appServicePlanName')]" },
           "sku": { "value": "[parameters('sku')]" },
           "tier": { "value": "[parameters('tier')]" },
-          "KeyVaultCertificateSecretName": { "value": "[parameters('KeyVaultCertificateSecretName')]" }
+          "KeyVaultSecretName": { "value": "[parameters('KeyVaultSecretName')]" },
+          "KeyVaultId": { "value": "reference('KeyVault').outputs.resourceID.value" }
 
         }
       }

--- a/vh-core-infra/azuredeploy.json
+++ b/vh-core-infra/azuredeploy.json
@@ -155,7 +155,7 @@
           "sku": { "value": "[parameters('sku')]" },
           "tier": { "value": "[parameters('tier')]" },
           "KeyVaultSecretName": { "value": "[parameters('KeyVaultCertificateSecretName')]" },
-          "KeyVaultId": { "value": "reference('KeyVault').outputs.AzureKeyVaultResourceId.value" }
+          "KeyVaultId": { "value": "[reference('KeyVault').outputs.AzureKeyVaultResourceId.value]" }
 
         }
       }

--- a/vh-core-infra/azuredeploy.json
+++ b/vh-core-infra/azuredeploy.json
@@ -140,7 +140,7 @@
       "name": "AzureAppServicePlan",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2016-09-01",
-      "dependsOn": [],
+      "dependsOn": [ "KeyVault" ],
       "properties": {
         "mode": "Incremental",
         "templateLink": {

--- a/vh-core-infra/azuredeploy.parameters.json
+++ b/vh-core-infra/azuredeploy.parameters.json
@@ -31,6 +31,9 @@
     },
     "redisCacheName": {
       "value": "redisCacheName"
+    },
+    "KeyVaultCertificateSecretName": {
+      "value": "KeyVaultCertificateSecretName"
     }
   }
 }


### PR DESCRIPTION
Moved certificate import process from web app provisioning steps over to App Service plan provisioning steps. This will allow to avoid conflicts when importing certificates during Web App provisionig on the same App Service plan.